### PR TITLE
Fix anchor links

### DIFF
--- a/src/util/remark.js
+++ b/src/util/remark.js
@@ -37,6 +37,16 @@ export function heading() {
 }
 
 /*
+ * Make anchor links consistent inside files.
+ */
+export function resetSluggerBetweenFiles() {
+	return ast =>
+		visit(ast, 'root', () => {
+			slugger.reset();
+		});
+}
+
+/*
  * Fix links: Configuration.md → docs/configuration
  */
 export function link() {


### PR DESCRIPTION
We didn't reset slugger between files and as a result, we had
inconsistent ids in sections and headers because of other files
influence with the same slugged header id.

iss: #7, https://github.com/styleguidist/react-styleguidist/issues/1324

Currently, you can't navigate properly by using this link https://react-styleguidist.js.org/docs/configuration.html#sections, because the actual section has an id `sections-1`.

Here how it works with this PR.
![fixed-anchor-links](https://user-images.githubusercontent.com/5443359/58661266-1e357700-8330-11e9-833b-54e850cc6b70.gif)
